### PR TITLE
Add function for retrieving git status and add branch symbol back

### DIFF
--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -138,6 +138,14 @@ local function get_git_dir(path)
         or (parent_path ~= path and get_git_dir(parent_path) or nil)
 end
 
+---
+ -- Get the status of working dir
+ -- @return {bool}
+---
+function get_git_status()
+    return os.execute("git diff --quiet --ignore-submodules HEAD")
+end
+
 -- adopted from clink.lua
 -- Modified to add colors and arrow symbols
 function colorful_git_prompt_filter()
@@ -167,7 +175,7 @@ function colorful_git_prompt_filter()
                 closingcolor = closingcolors.dirty
             end
 
-            clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color..branch..closingcolor)
+            clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."  "..branch..closingcolor)
             return false
         end
     end


### PR DESCRIPTION
Looks like your configuration was missing a few things from your gist: https://gist.github.com/AmrEldib/1d31cd54409a8ec612df#file-git-lua

Love this btw! :+1: 