### PR TITLE
Added environment label

### DIFF
--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -1,15 +1,26 @@
 -- Source: https://github.com/AmrEldib/cmder-powerline-prompt 
 
+local arrowSymbol = ""
+local arrowLeftSymbol = ""
+local branchSymbol = ""
+
 -- Resets the prompt 
 function lambda_prompt_filter()
-    cwd = clink.get_cwd()
-    prompt = "\x1b[37;44m{cwd} {git}{hg}\n\x1b[1;30;40m{lamb} \x1b[0m"
-    new_value = string.gsub(prompt, "{cwd}", cwd)
-    clink.prompt.value = string.gsub(new_value, "{lamb}", "λ")
-end
+    local cwd = clink.get_cwd()
+    local prompt = "\x1b[37;44m{cwd} {git}{hg} {env}\n\x1b[1;32;40m{lamb} \x1b[0m"
+    prompt = string.gsub(prompt, "{cwd}", cwd)
 
-local arrowSymbol = ""
-local branchSymbol = ""
+    local old_prompt = clink.prompt.value
+    local env = old_prompt:match('%[33;22;49m%((.+)%).+%[39;22;49m')
+
+    if env == nil then
+        prompt = string.gsub(prompt, "{env}", "")
+    else
+        prompt = string.gsub(prompt, "{env}", "\x1b[35;40m"..arrowLeftSymbol.."\x1b[37;45m "..env.." \x1b[35;40m"..arrowSymbol.."\x1b[0m")
+    end
+
+    clink.prompt.value = string.gsub(prompt, "{lamb}", "λ")
+end
 
 --- copied from clink.lua
  -- Resolves closest directory location for specified directory.

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -112,6 +112,29 @@ end
 
 -- copied from clink.lua
 -- clink.lua is saved under %CMDER_ROOT%\vendor
+-- Find out current branch
+-- @return {nil|git branch name}
+---
+local function get_git_branch(git_dir)
+    git_dir = git_dir or get_git_dir()
+
+    -- If git directory not found then we're probably outside of repo
+    -- or something went wrong. The same is when head_file is nil
+    local head_file = git_dir and io.open(git_dir..'/HEAD')
+    if not head_file then return end
+
+    local HEAD = head_file:read()
+    head_file:close()
+
+    -- if HEAD matches branch expression, then we're on named branch
+    -- otherwise it is a detached commit
+    local branch_name = HEAD:match('ref: refs/heads/(.+)')
+
+    return branch_name or 'HEAD detached at '..HEAD:sub(1, 7)
+end
+
+-- copied from clink.lua
+-- clink.lua is saved under %CMDER_ROOT%\vendor
 local function get_git_dir(path)
 
     -- return parent path for specified entry (either file or directory)


### PR DESCRIPTION
In the original cmder, there is another pair of round parentheses attached right after the git-branch ones sometimes.
![qq 20170209171648](https://cloud.githubusercontent.com/assets/17795845/22776739/d98b7d82-eeeb-11e6-88c0-b1e92b68be65.png)
At least in the repos directions of my Nodejs projects, it provides some useful messages to me (package name and version), so I tried to wrap that label into this "theme" of cmder prompt.
![qq 20170209170742](https://cloud.githubusercontent.com/assets/17795845/22776758/e09a47c0-eeeb-11e6-9339-ab0e375258e5.png)
