### PR TITLE
Add contents from PROMPT env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Cmder-powerline-prompt
 
-This is a custom prompt for [Cmder](http://cmder.net/) (the alternative console emulator for Windows). There's also a [PowerShell version](https://github.com/AmrEldib/cmder-powershell-powerline-prompt) of this prompt.  
-It looks like this:  
+This is a custom prompt for [Cmder](http://cmder.net/) (the alternative console emulator for Windows). There's also a 
+[PowerShell version](https://github.com/AmrEldib/cmder-powershell-powerline-prompt) of this prompt. It looks like this:  
+
 ![screenshot](screenshot.png)
 
 It has a blue background for the prompt.  
 For folders with git repos, you get yellow background for changes, and green for clean repos.  
-I'm using Consolas font.
 
 The look is inspired by [Powerline for Vim](https://github.com/powerline/powerline), and [Zsh's theme agnoster](https://github.com/agnoster/agnoster-zsh-theme).
+
+**Changes of this Fork:**
+
+- Support for virtual environments
+- Minor changes on color configs
 
 # Requirements
 
@@ -18,7 +23,7 @@ You'll be able to use any font in Cmder, but this font contains the symbols incl
 ## Font
 To use another font and still show symbols correctly:  
 - Go to Cmder Settings > Main  
-- Choose Main console font to be what you prefer  
+- Choose Main console font to be what you prefer (Recommended: *Consolas* - 18pt - **Bold**)
 - Choose _Alternative font_ to be _Anonymice Powerline_  
 - Modify the value of _Unicode ranges_ to add: `E0A0; E0B0;`  
 - Save Settings  
@@ -29,7 +34,7 @@ Download the `.lua` file, and place it in `%CMDER_ROOT%/config` folder.
 Restart Cmder to load the prompt.
 
 __Alternatively__, if you want to maintain link with the original repo, you can clone this repo into any folder  
-`git clone https://github.com/AmrEldib/cmder-powerline-prompt.git git-repo-folder-name`  
+`git clone https://github.com/igortg/cmder-powerline-prompt.git git-repo-folder-name`  
 then create a symbolic link from the `%CMDER_ROOT%/config` folder to the `.lua` file.  
 ```
 cd %CMDER_ROOT%/config  

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -1,4 +1,4 @@
--- Source: https://github.com/AmrEldib/cmder-powerline-prompt 
+-- Source: https://github.com/AmrEldib/cmder-powerline-prompt
 
 --- promptValue is whether the displayed prompt is the full path or only the folder name
  -- Use:
@@ -15,15 +15,35 @@ local function get_folder_name(path)
 	return string.sub(path, string.len(path) - slashIndex + 2)
 end
 
--- Resets the prompt 
+-- Resets the prompt
 function lambda_prompt_filter()
+    local old_prompt = clink.prompt.value
     cwd = clink.get_cwd()
 	if promptValue == promptValueFolder then
 		cwd =  get_folder_name(cwd)
 	end
-    prompt = "\x1b[37;44m{cwd} {git}{hg}\n\x1b[1;30;40m{lamb} \x1b[0m"
+
+    -- environment systems like pythons virtualenv change the PROMPT and usually
+    -- set some variable. But the variables are differently named and we would never
+    -- get them all, so try to parse the env name out of the PROMPT.
+    -- envs are usually put in round or square parentheses and before the old prompt
+    local env = old_prompt:match('.*%([.*]%)%sλ')
+    -- also check for square brackets
+    if env == nil then env = old_prompt:match('.*%((.*)%)%sλ') end
+
+    if env == nil then
+		env = ""
+    else
+        env = "("..env..") "
+    end
+
+	lambda = "λ"
+	
+	prompt = "\x1b[37;44m{cwd} {git}{hg}\n\x1b[1;90;40m{env}\x1b[1;32;40m{lamb} \x1b[0m"
     new_value = string.gsub(prompt, "{cwd}", cwd)
-    clink.prompt.value = string.gsub(new_value, "{lamb}", "λ")
+    new_value = string.gsub(new_value, "{env}", env)
+
+    clink.prompt.value = string.gsub(new_value, "{lamb}", lambda)
 end
 
 local arrowSymbol = ""

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -240,10 +240,11 @@ function env_prompt_filter()
         end
     end
     clink.prompt.value = string.gsub(clink.prompt.value, "{env}", original_prompt_env)
+	return false
 end
 
 -- override the built-in filters
 clink.prompt.register_filter(lambda_prompt_filter, 55)
-clink.prompt.register_filter(env_prompt_filter, 55)
+clink.prompt.register_filter(env_prompt_filter, 60)
 clink.prompt.register_filter(colorful_hg_prompt_filter, 60)
 clink.prompt.register_filter(colorful_git_prompt_filter, 60)

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -245,6 +245,6 @@ end
 
 -- override the built-in filters
 clink.prompt.register_filter(lambda_prompt_filter, 55)
-clink.prompt.register_filter(env_prompt_filter, 60)
+clink.prompt.register_filter(env_prompt_filter, 56)
 clink.prompt.register_filter(colorful_hg_prompt_filter, 60)
 clink.prompt.register_filter(colorful_git_prompt_filter, 60)


### PR DESCRIPTION
Another PR to add support for virtual environments. It was the first thing that I missed on cmder-powerline-prompt. I took a look at the PR from @lionel-deglise to get some idea, but made a different implementation. The processing is made in a different filter, so it's more easily disabled if necessary.

