### PR TITLE
fix detection of dirty git repo

### DIFF
--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -186,7 +186,7 @@ end
  -- @return {bool}
 ---
 function get_git_status()
-    local file = io.popen("git --no-optional-lock status --porcelain 2>nul")
+    local file = io.popen("git --no-optional-locks status --porcelain 2>nul")
     for line in file:lines() do
         file:close()
         return false


### PR DESCRIPTION
The correct `git` flag is `--no-optional-locks` (plural), not `--no-optional-lock` (singular). This was breaking the command and causing dirty repos to be detected as clean. Compare to [`clink.lua` in the cmder repository](https://github.com/cmderdev/cmder/blob/master/vendor/clink.lua#L209).

Resolves #31.