### PR TITLE
Add python virtual env support

### DIFF
--- a/_powerline_config.lua.sample
+++ b/_powerline_config.lua.sample
@@ -51,3 +51,9 @@ plc_git_conflictSymbol = "!"
 
 -- OPTIONAL. npm Symbol used in the NPM segment as visual indicator.
 --plc_npm_npmSymbol = "NPM"
+
+-- OPTIONAL. Snake Symbol used in the Python segment as visual indicator.
+-- plc_python_pythonSymbol = "🐍"
+
+-- REQUIRED. Only show virtual env in directories which contain a .py file
+plc_python_alwaysShow = false

--- a/powerline_core.lua
+++ b/powerline_core.lua
@@ -202,10 +202,13 @@ end
 ---
 -- Closes the prompts with a new line and the lamb symbol
 ---
-function closePrompt() 
-	clink.prompt.value = clink.prompt.value..newLineSymbol..plc_prompt_lambSymbol.." "
+function newLinePrompt() 
+	clink.prompt.value = clink.prompt.value..newLineSymbol
 end
 
+function closePrompt() 
+	clink.prompt.value = clink.prompt.value..plc_prompt_lambSymbol.." "
+end
 ---
 -- Gets the .git directory
 -- copied from clink.lua
@@ -254,4 +257,5 @@ end
 
 -- Register filters for resetting the prompt and closing it before and after all addons
 clink.prompt.register_filter(resetPrompt, 51)
+clink.prompt.register_filter(newLinePrompt,90)
 clink.prompt.register_filter(closePrompt, 99)

--- a/powerline_core.lua
+++ b/powerline_core.lua
@@ -202,13 +202,10 @@ end
 ---
 -- Closes the prompts with a new line and the lamb symbol
 ---
-function newLinePrompt() 
-	clink.prompt.value = clink.prompt.value..newLineSymbol
+function closePrompt() 
+	clink.prompt.value = clink.prompt.value..newLineSymbol..plc_prompt_lambSymbol.." "
 end
 
-function closePrompt() 
-	clink.prompt.value = clink.prompt.value..plc_prompt_lambSymbol.." "
-end
 ---
 -- Gets the .git directory
 -- copied from clink.lua
@@ -257,5 +254,4 @@ end
 
 -- Register filters for resetting the prompt and closing it before and after all addons
 clink.prompt.register_filter(resetPrompt, 51)
-clink.prompt.register_filter(newLinePrompt,90)
 clink.prompt.register_filter(closePrompt, 99)

--- a/powerline_python_venv.lua
+++ b/powerline_python_venv.lua
@@ -1,35 +1,87 @@
-local   function get_virtual_env(env_var)
-            env_path = clink.get_env(env_var)
-            if env_path then
-                return env_path
-            end
+---
+ -- get the virtual env variable
+---
+local function get_virtual_env(env_var)
+
+    local venv_path = false
+    -- return the folder name of the current virtual env, or false
+    local function get_virtual_env_var(var)
+        env_path = clink.get_env(var)
+        if env_path then
+            return string.match(env_path, "[^\\/:]+$")
+        else
             return false
         end
+    end
+
+    local venv = get_virtual_env_var(env_var) or get_virtual_env_var('VIRTUAL_ENV') or get_virtual_env_var('CONDA_DEFAULT_ENV') or false
+    return venv
+end
 
 ---
- -- add conda env name 
+ -- check for python files in current directory
 ---
-local   function conda_prompt_filter()
-            -- add in python virtual env name
-            local python_env = get_virtual_env('CONDA_DEFAULT_ENV')
-            if venv then
-                local venv_short = string.match(venv, "[^\\/:]+$")
-                clink.prompt.value = clink.prompt.value.."["..venv_short.."] "
-            end
+local function get_py_files(path)
+    local function pathname(path)
+        local prefix = ""
+        local i = path:find("[\\/:][^\\/:]*$")
+        if i then
+                prefix = path:sub(1, i-1)
         end
+        return prefix
+    end
 
+    local function has_py_files(dir)
+        local pyfile = clink.match_files("*.py", dir)
+        return pyfile
+    end
+
+    if not path or path == '.' then path = clink.get_cwd() end
+
+    dir = pathname(path)
+
+    files = has_py_files(dir) > 0
+    return files
+end
+
+-- * Segment object with these properties:
+---- * isNeeded: sepcifies whether a segment should be added or not. For example: no Git segment is needed in a non-git folder
+---- * text
+---- * textColor: Use one of the color constants. Ex: colorWhite
+---- * fillColor: Use one of the color constants. Ex: colorBlue
+local segment = {
+    isNeeded = false,
+    text = "",
+    textColor = colorWhite,
+    fillColor = colorCyan
+}
 ---
- -- add virtual env name 
+-- Sets the properties of the Segment object, and prepares for a segment to be added
 ---
-local   function venv_prompt_filter()
-            -- add in virtual env name
-            local venv = get_virtual_env('VIRTUAL_ENV')
-            if venv then
-                local venv_short = string.match(venv, "[^\\/:]+$")
-                clink.prompt.value = clink.prompt.value.."["..venv_short.."] "
-            end
+local function init()
+    if plc_python_virtualEnvVariable then
+        segment.isNeeded = get_virtual_env(plc_python_virtualEnvVariable)
+    else
+        segment.isNeeded = get_virtual_env()
+    end
+
+    if not plc_python_alwaysShow and not get_py_files() then segment.isNeeded = false end
+
+    if segment.isNeeded then
+        if plc_python_pythonSymbol then
+            segment.text = " "..plc_python_pythonSymbol.." ["..segment.isNeeded.."] "
+        else
+            segment.text = " ["..segment.isNeeded.."] "
         end
+    end
+end
+
+local function addAddonSegment()
+    init()
+    if segment.isNeeded then
+        addSegment(segment.text, segment.textColor, segment.fillColor)
+    end
+end
 
 -- register the filters
-clink.prompt.register_filter(conda_prompt_filter, 95)
-clink.prompt.register_filter(venv_prompt_filter, 95)
+clink.prompt.register_filter(addAddonSegment, 59)

--- a/powerline_python_venv.lua
+++ b/powerline_python_venv.lua
@@ -1,0 +1,35 @@
+local   function get_virtual_env(env_var)
+            env_path = clink.get_env(env_var)
+            if env_path then
+                return env_path
+            end
+            return false
+        end
+
+---
+ -- add conda env name 
+---
+local   function conda_prompt_filter()
+            -- add in python virtual env name
+            local python_env = get_virtual_env('CONDA_DEFAULT_ENV')
+            if venv then
+                local venv_short = string.match(venv, "[^\\/:]+$")
+                clink.prompt.value = clink.prompt.value.."["..venv_short.."] "
+            end
+        end
+
+---
+ -- add virtual env name 
+---
+local   function venv_prompt_filter()
+            -- add in virtual env name
+            local venv = get_virtual_env('VIRTUAL_ENV')
+            if venv then
+                local venv_short = string.match(venv, "[^\\/:]+$")
+                clink.prompt.value = clink.prompt.value.."["..venv_short.."] "
+            end
+        end
+
+-- register the filters
+clink.prompt.register_filter(conda_prompt_filter, 95)
+clink.prompt.register_filter(venv_prompt_filter, 95)


### PR DESCRIPTION
I wanted to add a plugin for virtualenv support which followed the convention of adding in [ ] before the prompt. To do this I needed to insert _after_ the newline and _before_ the lambda - the easiest way of doing this was to split the closePrompt function in two, so that plugins could be registered between.