### PR TITLE
Fix gitSymbol in powerline_prompt.lua

### DIFF
--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -62,8 +62,8 @@ local function init()
             if plc_prompt_type == promptTypeSmart then
                 if git_dir then
                     cwd = get_folder_name(cwd)
-                    if plc_npm_gitSymbol then
-                        cwd = gitSymbol.." "..cwd
+                    if plc_prompt_gitSymbol then
+                        cwd = plc_prompt_gitSymbol.." "..cwd
                     end
                 end
                 -- if not git dir leave the full path


### PR DESCRIPTION
The _powerline_config.lua.sample uses `plc_prompt_gitSymbol`, update powerline_prompt.lua accordingly.