### PR TITLE
Enabled, refactored, and enhanced, the Mercurial prompt code.

### DIFF
--- a/powerline_hg.lua
+++ b/powerline_hg.lua
@@ -1,5 +1,18 @@
---[[
-
+-- Constants
+local segmentColors = {
+    branch = {
+        fill = colorGreen,
+        text = colorBlack
+    },
+    clean = {
+        fill = colorGreen,
+        text = colorWhite
+    },
+    dirty = {
+        fill = colorRed,
+        text = colorWhite
+    }
+}
 
 --- copied from clink.lua
  -- Resolves closest directory location for specified directory.
@@ -52,44 +65,62 @@ local function get_dir_contains(path, dirname)
     end
 end
 
-
 -- copied from clink.lua
 -- clink.lua is saved under %CMDER_ROOT%\vendor
-local function get_hg_dir(path)
+ function get_hg_dir(path)
     return get_dir_contains(path, '.hg')
 end
 
--- adopted from clink.lua
--- clink.lua is saved under %CMDER_ROOT%\vendor
-function colorful_hg_prompt_filter()
+-- * The segments{} table will hold values for each prompt segment to be (sequentially) displayed
+---- * text
+---- * textColor: Use one of the color constants. Ex: colorWhite
+---- * fillColor: Use one of the color constants. Ex: colorBlue
 
-    -- Colors for mercurial status
-    local colors = {
-        clean = "\x1b[1;37;40m",
-        dirty = "\x1b[31;1m",
-    }
+local segments = {}
+
+---
+-- Sets the properties of the Segment object, and prepares for a segment to be added
+---
+local function init()
+    segments = {}
 
     if get_hg_dir() then
-        -- if we're inside of mercurial repo then try to detect current branch
-        local branch = get_hg_branch()
-        if branch then
-            -- Has branch => therefore it is a mercurial folder, now figure out status
-            if get_hg_status() then
-                color = colors.clean
-            else
-                color = colors.dirty
+        -- if we're inside of git repo then try to detect current branch
+        -- 'hg id' gives us BOTH the branch name AND an indicator that there
+        -- are uncommitted changes, in one fast(er) call
+        local pipe = io.popen("hg id 2>&1")
+        local output = pipe:read('*all')
+        local rc = { pipe:close() }
+
+        if output ~= nil and
+           string.sub(output,1,7) ~= "abort: " and             -- not an HG working copy
+           string.sub(output,1,12) ~= "000000000000" and       -- empty wc (needs update)
+           (not string.find(output, "is not recognized")) then -- 'hg' not in path
+            local items = {}
+            for i in string.gmatch(output, "%S+") do
+                table.insert(items, i)
             end
 
-            clink.prompt.value = string.gsub(clink.prompt.value, "{hg}", color.."("..branch..")")
-            return false
+            -- Branch segment
+            table.insert(segments, {" " .. plc_git_branchSymbol .. " " .. items[2] .. " ", segmentColors.branch.text, segmentColors.branch.fill})
+
+            if string.sub(items[1], -1, -1) == "+" then
+                -- Dirty segment
+                table.insert(segments, {"  ",  segmentColors.dirty.text,  segmentColors.dirty.fill})
+            end
         end
     end
+end 
 
-    -- No mercurial present or not in mercurial file
-    clink.prompt.value = string.gsub(clink.prompt.value, "{hg}", "")
-    return false
-end
+---
+-- Uses the segment properties to add a new segment to the prompt
+---
+local function addAddonSegment()
+    init()
+    for i = 1, #segments do
+        addSegment(segments[i][1], segments[i][2], segments[i][3])
+    end
+end 
 
-clink.prompt.register_filter(colorful_hg_prompt_filter, 60)
-
-]]
+-- Register this addon with Clink
+clink.prompt.register_filter(addAddonSegment, 61)


### PR DESCRIPTION
I have activated the Mercurial portion of the Powerline Prompt, and made some slight enhancements.

This change uses the E003 code point of the "Anonymice Powerline" font to indicate a "dirty" working copy.

![image](https://user-images.githubusercontent.com/4536448/42406107-84a4310e-815e-11e8-9942-28a524f3e5a8.png)
