### PR TITLE
Miscellaneous Changes and Improvements

### DIFF
--- a/_powerline_config.lua.sample
+++ b/_powerline_config.lua.sample
@@ -29,11 +29,12 @@ plc_prompt_type = "smart"
  -- Use true or false
  -- default is true
 plc_prompt_useHomeSymbol = true
---- REQUIRED
+--- OPTIONAL
  -- changes the environment variable where the home symbol will be shown (if enabled)
- -- examples: "HOME", "USERPROFILE", "HOMEDRIVE", etc
- -- default: "HOME"
-plc_home_env = "HOME"
+ -- Use:
+ -- "HOME", "USERPROFILE", "HOMEDRIVE", etc
+ -- default is "HOME"
+--plc_prompt_homeSymbolEnvironment = "USERPROFILE"
 
 -- Symbols
 -- REQUIRED. Prompt displayed instead of user's home folder e.g. C:\Users\username

--- a/_powerline_config.lua.sample
+++ b/_powerline_config.lua.sample
@@ -22,13 +22,18 @@
  -- Use:
  -- "full" for full path like C:\Windows\System32
  -- "folder" for folder name only like System32
- -- "smart" to switch in git repo to folder name instead of full path 
+ -- "smart" to switch in git repo to folder name instead of full path
  -- default is full
 plc_prompt_type = "smart"
 --- REQUIRED. powerline_config_prompt_useHomeSymbol is whether to show ~ instead of the full path to the user's home folder
  -- Use true or false
  -- default is true
-plc_prompt_useHomeSymbol = true  
+plc_prompt_useHomeSymbol = true
+--- REQUIRED
+ -- changes the environment variable where the home symbol will be shown (if enabled)
+ -- examples: "HOME", "USERPROFILE", "HOMEDRIVE", etc
+ -- default: "HOME"
+plc_home_env = "HOME"
 
 -- Symbols
 -- REQUIRED. Prompt displayed instead of user's home folder e.g. C:\Users\username
@@ -49,7 +54,7 @@ plc_git_conflictSymbol = "!"
 -- OPTIONAL. Git symbol used in the folder segment when 'smart' prompt is used and the user navigates to a folder with Git repo
 --plc_prompt_gitSymbol = "GIT"
 
--- REQUIRED. Hg branch symbol. Used to indicate the name of a branch 
+-- REQUIRED. Hg branch symbol. Used to indicate the name of a branch
 plc_hg_branchSymbol = ""
 
 -- REQUIRED. Hg conflict symbol. Used to indicate there's a conflict.

--- a/powerline_core.lua
+++ b/powerline_core.lua
@@ -101,9 +101,9 @@ newLineSymbol = "\n"
 -- Default symbols
 -- Some symbols are required. If the user fails to provide them in the config file, they're created here
 -- Prompt displayed instead of user's home folder e.g. C:\Users\username
-if not plc_prompt_homeSymbol then 
+if not plc_prompt_homeSymbol then
 	plc_prompt_homeSymbol = "~"
-end 
+end
 -- Symbol connecting each segment of the prompt. Be careful before you change this.
 if not plc_prompt_arrowSymbol then
 	plc_prompt_arrowSymbol = ""
@@ -115,7 +115,7 @@ end
 -- Version control (e.g. Git) branch symbol. Used to indicate the name of a branch.
 if not plc_git_branchSymbol then
 	plc_git_branchSymbol = ""
-end 
+end
 -- Version control (e.g. Git) conflict symbol. Used to indicate there's a conflict.
 if not plc_git_conflictSymbol then
 	plc_git_conflictSymbol = "!"
@@ -134,7 +134,7 @@ function addArrow(text, oldColor, newColor)
 	-- An arrow is a character written using the old color on a background of the new color
 	text = addTextWithColor(text, plc_prompt_arrowSymbol, oldColor.foreground, newColor.background)
 	return text
-end 
+end
 
 ---
 -- Adds text to the input text with the correct colors
@@ -145,7 +145,7 @@ end
 -- @return {string} concatination of the the two input text with the correct color formatting.
 ---
 function addTextWithColor(text, textToAdd, textColorValue, fillColorValue)
-	-- let's say the 
+	-- let's say the
 	-- fillColorValue is 41
 	-- textColorValue is 30
 	-- textToAdd is "Hello"
@@ -153,8 +153,8 @@ function addTextWithColor(text, textToAdd, textColorValue, fillColorValue)
 	-- which add Hello with red background and black letters
 	-- [0m at the end turns off all attributes
 	text = text..ansiEscChar.."["..textColorValue..";"..fillColorValue.."m"..textToAdd..ansiEscChar.."[0m"
-	return text 
-end 
+	return text
+end
 
 ---
 -- Adds a new segment to the prompt with the specified colors.
@@ -163,18 +163,18 @@ end
 -- fillColor {color} Background color of the new segment. Use one of the color constants as input.
 -- @return {nil} The prompt is reset with the new segments
 ---
-function addSegment(text, textColor, fillColor) 	
+function addSegment(text, textColor, fillColor)
 	local newPrompt = ""
 	-- If there's an existing segment
-	if currentSegments == "" then 
+	if currentSegments == "" then
 		newPrompt = ""
-	else 
-		-- Remove the existing arrow 
+	else
+		-- Remove the existing arrow
 		-- The last arrow with all its surrounding escape characters and graphics mode settings count as 7 characters
 		newPrompt = string.sub(currentSegments, 0, string.len(currentSegments) - 7)
 		-- Add arrow with color of new segment
 		newPrompt = addArrow(newPrompt, currentFillColor, fillColor)
-	end 
+	end
 	-- Write the text with the fill color
 	newPrompt = addTextWithColor(newPrompt, text, textColor.foreground, fillColor.background)
 	-- Write the closing arrow
@@ -187,7 +187,7 @@ function addSegment(text, textColor, fillColor)
 
 	-- Update clink prompt
 	clink.prompt.value = newPrompt
-end 
+end
 
 ---
 -- Resets the prompt and all state variables
@@ -195,14 +195,14 @@ end
 function resetPrompt()
 	clink.prompt.value = ""
 	currentSegments = ""
-	currentFillColor = colorBlue 
-	currentTextColor = colorWhite 
+	currentFillColor = colorBlue
+	currentTextColor = colorWhite
 end
 
 ---
 -- Closes the prompts with a new line and the lamb symbol
 ---
-function closePrompt() 
+function closePrompt()
 	clink.prompt.value = clink.prompt.value..newLineSymbol..plc_prompt_lambSymbol.." "
 end
 

--- a/powerline_git.lua
+++ b/powerline_git.lua
@@ -89,7 +89,7 @@ local segment = {
 -- Sets the properties of the Segment object, and prepares for a segment to be added
 ---
 local function init()
-    segment.isNeeded = get_git_dir()    
+    segment.isNeeded = get_git_dir()
     if segment.isNeeded then
         -- if we're inside of git repo then try to detect current branch
         local branch = get_git_branch(git_dir)
@@ -105,9 +105,9 @@ local function init()
                 segment.fillColor = segmentColors.conflict.fill
                 if plc_git_conflictSymbol then
                     segment.text = segment.text..plc_git_conflictSymbol
-                end 
+                end
                 return
-            end 
+            end
 
             if gitStatus then
                 segment.textColor = segmentColors.clean.text
@@ -121,17 +121,17 @@ local function init()
             segment.text = segment.text.."± "
         end
     end
-end 
+end
 
 ---
 -- Uses the segment properties to add a new segment to the prompt
 ---
 local function addAddonSegment()
     init()
-    if segment.isNeeded then 
+    if segment.isNeeded then
         addSegment(segment.text, segment.textColor, segment.fillColor)
-    end 
-end 
+    end
+end
 
 -- Register this addon with Clink
 clink.prompt.register_filter(addAddonSegment, 61)

--- a/powerline_npm.lua
+++ b/powerline_npm.lua
@@ -50,22 +50,22 @@ local function init()
     end
 
     if plc_npm_npmSymbol then
-      segment.text = " "..npmSymbol.." "..package_name.."@"..package_version.." "
+      segment.text = " "..plc_npm_npmSymbol.." "..package_name.."@"..package_version.." "
     else
       segment.text = " "..package_name.."@"..package_version.." "
-    end 
+    end
   end
-end 
+end
 
 ---
 -- Uses the segment properties to add a new segment to the prompt
 ---
 local function addAddonSegment()
   init()
-  if segment.isNeeded then 
+  if segment.isNeeded then
       addSegment(segment.text, segment.textColor, segment.fillColor)
-  end 
-end 
+  end
+end
 
 -- Register this addon with Clink
 clink.prompt.register_filter(addAddonSegment, 60)

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -64,7 +64,6 @@ local function init()
         end
         if plc_prompt_useHomeSymbol and string.find(cwd, clink.get_env(plc_prompt_homeSymbolEnvironment)) and git_dir ==nil then
             -- in both smart and full if we are in home, behave like a proper command line
-            git_root_dir = nil
             cwd = string.gsub(cwd, clink.get_env(plc_prompt_homeSymbolEnvironment), plc_prompt_homeSymbol)
         else
             -- either not in home or home not supported then check the smart path
@@ -79,7 +78,8 @@ local function init()
                         cwd = plc_prompt_gitSymbol.." "..cwd
                     end
                 end
-                -- if not git dir leave the full path
+                -- if not git dir leave the full path and reset the git_root_dir
+                git_root_dir = nil
             end
         end
     end

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -66,8 +66,8 @@ local function init()
             if plc_prompt_type == promptTypeSmart then
                 if git_dir then
                     cwd = get_folder_name(cwd)
-                    if plc_npm_gitSymbol then
-                        cwd = gitSymbol.." "..cwd
+                    if plc_prompt_gitSymbol then
+                        cwd = plc_prompt_gitSymbol.." "..cwd
                     end
                 end
                 -- if not git dir leave the full path

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -16,9 +16,8 @@ end
 if not plc_prompt_useHomeSymbol then
 	plc_prompt_useHomeSymbol = true
 end
--- default is "HOME"
-if not plc_home_env then
-    plc_home_env = "HOME"
+if not plc_prompt_homeSymbolEnvironment then
+    plc_prompt_homeSymbolEnvironment = "HOME"
 end
 
 -- Extracts only the folder name from the input Path
@@ -63,10 +62,10 @@ local function init()
             -- get the root of the git directory and save it
             git_root_dir = git_dir:gsub("/.git", "")
         end
-        if plc_prompt_useHomeSymbol and string.find(cwd, clink.get_env(plc_home_env)) and git_dir ==nil then
+        if plc_prompt_useHomeSymbol and string.find(cwd, clink.get_env(plc_prompt_homeSymbolEnvironment)) and git_dir ==nil then
             -- in both smart and full if we are in home, behave like a proper command line
             git_root_dir = nil
-            cwd = string.gsub(cwd, clink.get_env(plc_home_env), plc_prompt_homeSymbol)
+            cwd = string.gsub(cwd, clink.get_env(plc_prompt_homeSymbolEnvironment), plc_prompt_homeSymbol)
         else
             -- either not in home or home not supported then check the smart path
             if plc_prompt_type == promptTypeSmart then

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -71,8 +71,10 @@ local function init()
             if plc_prompt_type == promptTypeSmart then
                 if git_dir then
                     -- get the root git folder name and reappend any part of the directory that comes after
-                    -- replace special characters that might be in the directory name first
-                    cwd = get_folder_name(git_root_dir)..cwd:gsub("%-",""):gsub("(.*)("..git_root_dir..")", "")
+                    -- replaces all special characters in cwd with "" and then replaces the cwd up to git_root_dir with ""
+                    -- Ex: C:\Users\username\cmder-powerline-prompt\innerdir -> cmder-powerline-prompt\innerdir
+                    local appended_dir = cwd:gsub("[%(%)%.%%%+%-%*%?%[%^%&]",""):gsub("(.*)("..git_root_dir..")", "")
+                    cwd = get_folder_name(git_root_dir)..appended_dir
                     if plc_prompt_gitSymbol then
                         cwd = plc_prompt_gitSymbol.." "..cwd
                     end

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -5,16 +5,20 @@
 local promptTypeFull = "full"
  -- "folder" for folder name only like System32
 local promptTypeFolder = "folder"
- -- "smart" to switch in git repo to folder name instead of full path 
+ -- "smart" to switch in git repo to folder name instead of full path
 local promptTypeSmart = "smart"
 
  -- default is promptTypeFull
  -- Set default value if no value is already set
 if not plc_prompt_type then
     plc_prompt_type = promptTypeFull
-end 
-if not plc_prompt_useHomeSymbol then 
-	plc_prompt_useHomeSymbol = true 
+end
+if not plc_prompt_useHomeSymbol then
+	plc_prompt_useHomeSymbol = true
+end
+-- default is "HOME"
+if not plc_home_env then
+    plc_home_env = "HOME"
 end
 
 -- Extracts only the folder name from the input Path
@@ -34,7 +38,7 @@ end
 local segment = {
     isNeeded = true,
     text = "",
-    textColor = colorWhite, 
+    textColor = colorWhite,
     fillColor = colorBlue
 }
 
@@ -48,16 +52,16 @@ local function init()
     -- show just current folder
     if plc_prompt_type == promptTypeFolder then
 		cwd =  get_folder_name(cwd)
-    else    
+    else
     -- show 'smart' folder name
     -- This will show the full folder path unless a Git repo is active in the folder
     -- If a Git repo is active, it will only show the folder name
     -- This helps users avoid having a super long prompt
         local git_dir = get_git_dir()
-        if plc_prompt_useHomeSymbol and string.find(cwd, clink.get_env("HOME")) and git_dir ==nil then 
+        if plc_prompt_useHomeSymbol and string.find(cwd, clink.get_env(plc_home_env)) and git_dir ==nil then
             -- in both smart and full if we are in home, behave like a proper command line
-            cwd = string.gsub(cwd, clink.get_env("HOME"), plc_prompt_homeSymbol)
-        else 
+            cwd = string.gsub(cwd, clink.get_env(plc_home_env), plc_prompt_homeSymbol)
+        else
             -- either not in home or home not supported then check the smart path
             if plc_prompt_type == promptTypeSmart then
                 if git_dir then
@@ -70,9 +74,9 @@ local function init()
             end
         end
     end
-	
+
 	segment.text = " "..cwd.." "
-end 
+end
 
 ---
 -- Uses the segment properties to add a new segment to the prompt
@@ -80,7 +84,7 @@ end
 local function addAddonSegment()
     init()
     addSegment(segment.text, segment.textColor, segment.fillColor)
-end 
+end
 
 -- Register this addon with Clink
 clink.prompt.register_filter(addAddonSegment, 55)

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -45,6 +45,7 @@ local segment = {
 ---
 -- Sets the properties of the Segment object, and prepares for a segment to be added
 ---
+local git_root_dir = nil
 local function init()
     -- fullpath
     cwd = clink.get_cwd()
@@ -58,14 +59,21 @@ local function init()
     -- If a Git repo is active, it will only show the folder name
     -- This helps users avoid having a super long prompt
         local git_dir = get_git_dir()
+        if git_dir and git_root_dir == nil then
+            -- get the root of the git directory and save it
+            git_root_dir = git_dir:gsub("/.git", "")
+        end
         if plc_prompt_useHomeSymbol and string.find(cwd, clink.get_env(plc_home_env)) and git_dir ==nil then
             -- in both smart and full if we are in home, behave like a proper command line
+            git_root_dir = nil
             cwd = string.gsub(cwd, clink.get_env(plc_home_env), plc_prompt_homeSymbol)
         else
             -- either not in home or home not supported then check the smart path
             if plc_prompt_type == promptTypeSmart then
                 if git_dir then
-                    cwd = get_folder_name(cwd)
+                    -- get the root git folder name and reappend any part of the directory that comes after
+                    -- replace special characters that might be in the directory name first
+                    cwd = get_folder_name(git_root_dir)..cwd:gsub("%-",""):gsub("(.*)("..git_root_dir..")", "")
                     if plc_prompt_gitSymbol then
                         cwd = plc_prompt_gitSymbol.." "..cwd
                     end


### PR DESCRIPTION
- I found that the `~` symbol didn't seem to be working for my Cmder setup. I dug into the code and found that that symbol was being set when the user was in the `HOME` directory. My `HOME` directory is set to a location other than `C:\users\myname`, which would explain why the `~` appeared to not be working for me.  I added a config setting that would allow the specification of a different environment variable other than `HOME`. For me, I have that set to `USERPROFILE`, but someone might want it to be `HOMEDRIVE` or another environment variable.
- Neither the optional git or npm symbols were working; the wrong variables were being used.
- I changed the way that the `smart` prompt type worked in git directories:
  - Before, just the folder would show. So if my git directory was `C:\Users\me\cmder-powerline-prompt` and I was inside the 'docs' folder, the folder would just show as `docs`. I figured that it would be better if it were to show `cmder-powerline-prompt\docs` to better give me an idea of where I was in the git directory.

I hope that these changes are useful! I know that they are (at least) to me, but I figured that maybe others would like them too.