### PR TITLE
Makes cmder-powerline-prompt work with absolute gitdir paths, by test…

### DIFF
--- a/powerline_core.lua
+++ b/powerline_core.lua
@@ -236,7 +236,10 @@ function get_git_dir(path)
 			local git_dir = gitfile:read():match('gitdir: (.*)')
 			gitfile:close()
 
-			return git_dir and dir..'/'..git_dir
+			-- gitdir can (apparently) be absolute or relative:
+			local file_when_absolute = git_dir and clink.is_dir(git_dir) and git_dir
+			local file_when_relative = git_dir and clink.is_dir(dir..'/'..git_dir) and dir..'/'..git_dir
+			return (file_when_absolute or file_when_relative)
 	end
 
 	-- Set default path to current directory


### PR DESCRIPTION
…ing the existence of the directories first.

Fixes #47 