### PR TITLE
Fix incorrectly named npmSymbol

### DIFF
--- a/powerline_npm.lua
+++ b/powerline_npm.lua
@@ -50,7 +50,7 @@ local function init()
     end
 
     if plc_npm_npmSymbol then
-      segment.text = " "..npmSymbol.." "..package_name.."@"..package_version.." "
+      segment.text = " "..plc_npm_npmSymbol.." "..package_name.."@"..package_version.." "
     else
       segment.text = " "..package_name.."@"..package_version.." "
     end 


### PR DESCRIPTION
I'm not sure this is the right way to fix this.

If you enable `plc_npm_npmSymbol` in the powerline config, then you get a crash because `npmSymbol` isn't actually defined anywhere.  I think that was supposed to point to `plc_npm_npmSymbol` instead.

Of course, the config and this file hasn't been changed in many months so either no one is using this, no one has bothered to submit a fix, or I'm doing this all wrong.