### PR TITLE
adjust to name defined in _powerline_config.lua

### DIFF
--- a/powerline_npm.lua
+++ b/powerline_npm.lua
@@ -50,7 +50,7 @@ local function init()
     end
 
     if plc_npm_npmSymbol then
-      segment.text = " "..npmSymbol.." "..package_name.."@"..package_version.." "
+      segment.text = " "..plc_npm_npmSymbol.." "..package_name.."@"..package_version.." "
     else
       segment.text = " "..package_name.."@"..package_version.." "
     end 


### PR DESCRIPTION
if name is defined in config, causes undefined error here.