### PR TITLE
Fix Chinese garbled code

### DIFF
--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -38,16 +38,22 @@ local segment = {
     fillColor = colorBlue
 }
 
+-- use lua.io to get current path
+local function getCurrentPath()
+    obj = io.popen("cd")
+    local currentPath = obj:read("*all"):sub(1,-2)
+    obj.close()
+    return currentPath
+end
+
+
 ---
 -- Sets the properties of the Segment object, and prepares for a segment to be added
 ---
 local function init()
 
     --* use lua.io to get current path
-    local cwd
-    obj=io.popen("cd")
-    cwd=obj:read("*all"):sub(1,-2)
-    obj:close()
+    local cwd = getCurrentPath()
 
     -- show just current folder
     if plc_prompt_type == promptTypeFolder then

--- a/powerline_prompt.lua
+++ b/powerline_prompt.lua
@@ -42,8 +42,12 @@ local segment = {
 -- Sets the properties of the Segment object, and prepares for a segment to be added
 ---
 local function init()
-    -- fullpath
-    cwd = clink.get_cwd()
+
+    --* use lua.io to get current path
+    local cwd
+    obj=io.popen("cd")
+    cwd=obj:read("*all"):sub(1,-2)
+    obj:close()
 
     -- show just current folder
     if plc_prompt_type == promptTypeFolder then


### PR DESCRIPTION
I use lua.io to get current path because I find Chinese path will appear garbled by using clink.getcwd()

**Result:**

![捕获](https://user-images.githubusercontent.com/44056372/85924898-c6b56200-b8c7-11ea-9f0d-3fbe074b3d0a.PNG)
