### PR TITLE
Set the closing arrow's background colour to default instead of black so it works fine with transparency in Windows Terminal.

### DIFF
--- a/powerline_core.lua
+++ b/powerline_core.lua
@@ -45,6 +45,7 @@ ansiFgClrBlue = "34"
 ansiFgClrMagenta = "35"
 ansiFgClrCyan = "36"
 ansiFgClrWhite = "37"
+ansiFgClrDefault = "39"
 -- ANSI Background Colors
 ansiBgClrBlack = "40"
 ansiBgClrRed = "41"
@@ -54,8 +55,13 @@ ansiBgClrBlue = "44"
 ansiBgClrMagenta = "45"
 ansiBgClrCyan = "46"
 ansiBgClrWhite = "47"
+ansiBgClrDefault = "49"
 
 -- Colors
+colorDefault = {
+	foreground = ansiFgClrDefault,
+	background = ansiBgClrDefault
+}
 colorBlack = {
 	foreground = ansiFgClrBlack,
 	background = ansiBgClrBlack
@@ -101,9 +107,9 @@ newLineSymbol = "\n"
 -- Default symbols
 -- Some symbols are required. If the user fails to provide them in the config file, they're created here
 -- Prompt displayed instead of user's home folder e.g. C:\Users\username
-if not plc_prompt_homeSymbol then 
+if not plc_prompt_homeSymbol then
 	plc_prompt_homeSymbol = "~"
-end 
+end
 -- Symbol connecting each segment of the prompt. Be careful before you change this.
 if not plc_prompt_arrowSymbol then
 	plc_prompt_arrowSymbol = ""
@@ -115,7 +121,7 @@ end
 -- Version control (e.g. Git) branch symbol. Used to indicate the name of a branch.
 if not plc_git_branchSymbol then
 	plc_git_branchSymbol = ""
-end 
+end
 -- Version control (e.g. Git) conflict symbol. Used to indicate there's a conflict.
 if not plc_git_conflictSymbol then
 	plc_git_conflictSymbol = "!"
@@ -134,7 +140,7 @@ function addArrow(text, oldColor, newColor)
 	-- An arrow is a character written using the old color on a background of the new color
 	text = addTextWithColor(text, plc_prompt_arrowSymbol, oldColor.foreground, newColor.background)
 	return text
-end 
+end
 
 ---
 -- Adds text to the input text with the correct colors
@@ -145,7 +151,7 @@ end
 -- @return {string} concatination of the the two input text with the correct color formatting.
 ---
 function addTextWithColor(text, textToAdd, textColorValue, fillColorValue)
-	-- let's say the 
+	-- let's say the
 	-- fillColorValue is 41
 	-- textColorValue is 30
 	-- textToAdd is "Hello"
@@ -153,8 +159,8 @@ function addTextWithColor(text, textToAdd, textColorValue, fillColorValue)
 	-- which add Hello with red background and black letters
 	-- [0m at the end turns off all attributes
 	text = text..ansiEscChar.."["..textColorValue..";"..fillColorValue.."m"..textToAdd..ansiEscChar.."[0m"
-	return text 
-end 
+	return text
+end
 
 ---
 -- Adds a new segment to the prompt with the specified colors.
@@ -163,22 +169,22 @@ end
 -- fillColor {color} Background color of the new segment. Use one of the color constants as input.
 -- @return {nil} The prompt is reset with the new segments
 ---
-function addSegment(text, textColor, fillColor) 	
+function addSegment(text, textColor, fillColor)
 	local newPrompt = ""
 	-- If there's an existing segment
-	if currentSegments == "" then 
+	if currentSegments == "" then
 		newPrompt = ""
-	else 
-		-- Remove the existing arrow 
+	else
+		-- Remove the existing arrow
 		-- The last arrow with all its surrounding escape characters and graphics mode settings count as 7 characters
 		newPrompt = string.sub(currentSegments, 0, string.len(currentSegments) - 7)
 		-- Add arrow with color of new segment
 		newPrompt = addArrow(newPrompt, currentFillColor, fillColor)
-	end 
+	end
 	-- Write the text with the fill color
 	newPrompt = addTextWithColor(newPrompt, text, textColor.foreground, fillColor.background)
 	-- Write the closing arrow
-	newPrompt = addArrow(newPrompt, fillColor, colorBlack)
+	newPrompt = addArrow(newPrompt, fillColor, colorDefault)
 
 	-- Update current values
 	currentSegments = newPrompt
@@ -187,7 +193,7 @@ function addSegment(text, textColor, fillColor)
 
 	-- Update clink prompt
 	clink.prompt.value = newPrompt
-end 
+end
 
 ---
 -- Resets the prompt and all state variables
@@ -195,14 +201,14 @@ end
 function resetPrompt()
 	clink.prompt.value = ""
 	currentSegments = ""
-	currentFillColor = colorBlue 
-	currentTextColor = colorWhite 
+	currentFillColor = colorBlue
+	currentTextColor = colorWhite
 end
 
 ---
 -- Closes the prompts with a new line and the lamb symbol
 ---
-function closePrompt() 
+function closePrompt()
 	clink.prompt.value = clink.prompt.value..newLineSymbol..plc_prompt_lambSymbol.." "
 end
 


### PR DESCRIPTION
Set the closing arrow's background colour to default instead of black so it works fine with transparency in Windows Terminal.

https://github.com/AmrEldib/cmder-powerline-prompt/issues/73

![image](https://user-images.githubusercontent.com/19678455/167237905-fda8182e-73a4-47c0-9d7d-36a2a2060f4d.png)